### PR TITLE
Fix binder!

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This repository uses a variety of computational approaches to predict whether a 
 
 ## How to run your own FASTA file through the pipeline using Binder
 
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/Arcadia-Science/2022-actin-prediction/binder)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/Arcadia-Science/2022-actin-prediction/main)
 
 <details>
   <summary>More information on binder and what happens when you click the launch binder button.</summary>
@@ -41,7 +41,7 @@ An overview is provided here with more detailed instructions below.
 You need to do three things to start the pipeline on your own FASTA sequence.
 We provide an overview of these steps first, and then provide more details below.
 
-1. Launch Binder [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/Arcadia-Science/2022-actin-prediction/binder)
+1. Launch Binder [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/Arcadia-Science/2022-actin-prediction/main)
 2. Upload your FASTA sequence to the Binder and edit the config file to tell the pipeline the name of your FASTA file.
 3. Start the snakemake pipeline.
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ You can find operating system-specific instructions for installing miniconda [he
 After installing conda and [mamba](https://mamba.readthedocs.io/en/latest/), run the following command to create the pipeline run environment.
 
 ```
-mamba env create -n actin --file environment.yml
+mamba env create -n actin --file actin_env.yml
 conda activate actin
 ```
 
@@ -179,7 +179,7 @@ See the [above section](#how-to-run-your-own-fasta-file-through-the-pipeline-usi
 ### Snakemake
 
 Snakemake manages rule-specific environments via the `conda` directive and using environment files in the `envs/` directory.
-Snakemake itself is installed in the main conda environment `actin` specified in the `environment.yml` file.
+Snakemake itself is installed in the main conda environment `actin` specified in the `actin_env.yml` file.
 
 Further details TBD.
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ From the Launcher tab, use the `Terminal` icon to open a new terminal.
 
 ![](https://i.imgur.com/SozBrHJ.png)
 
-Then, enter the command `snakemake -j 2` and allow the pipeline to run.
+Then, enter the command `snakemake -j 1` and allow the pipeline to run.
 If you uploaded a single protein, it should take about 1-2 minutes.
 As the pipeline starts, you should see something like:
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This repository uses a variety of computational approaches to predict whether a 
 
 ## How to run your own FASTA file through the pipeline using Binder
 
-[![Binder](https://aws-uswest2-binder.pangeo.io/badge_logo.svg)](https://aws-uswest2-binder.pangeo.io/v2/gh/Arcadia-Science/2022-actin-prediction/main)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/Arcadia-Science/2022-actin-prediction/binder)
 
 <details>
   <summary>More information on binder and what happens when you click the launch binder button.</summary>
@@ -41,7 +41,7 @@ An overview is provided here with more detailed instructions below.
 You need to do three things to start the pipeline on your own FASTA sequence.
 We provide an overview of these steps first, and then provide more details below.
 
-1. Launch Binder ([![Binder](https://aws-uswest2-binder.pangeo.io/badge_logo.svg)](https://aws-uswest2-binder.pangeo.io/v2/gh/Arcadia-Science/2022-actin-prediction/main))
+1. Launch Binder [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/Arcadia-Science/2022-actin-prediction/binder)
 2. Upload your FASTA sequence to the Binder and edit the config file to tell the pipeline the name of your FASTA file.
 3. Start the snakemake pipeline.
 
@@ -50,9 +50,6 @@ We provide an overview of these steps first, and then provide more details below
 The first step is to launch the Binder instance.
 Binder is a service that turns a Git repo into a collection of interactive notebooks that can be executed on a temporary cloud machine.
 Binder is currently free, so there is no cost to using it!
-We built the Binder for this repository on [Pangeo Binder](https://pangeo-binder.readthedocs.io/en/prod/).
-This BinderHub provides slightly more powerful compute, but [to combat users who were using the service illicitly](https://github.com/pangeo-data/pangeo-binder/issues/195), you have to login via GitHub and can only have one instance running at a time. 
-GitHub accounts are also free, so you can create one if you don't already have one.
 
 ### 2. Upload your FASTA sequence to the Binder and edit the config file to tell the pipeline the name of your FASTA file
 
@@ -83,7 +80,7 @@ From the Launcher tab, use the `Terminal` icon to open a new terminal.
 
 ![](https://i.imgur.com/SozBrHJ.png)
 
-Then, enter the command `snakemake --use-conda -j 2` and allow the pipeline to run.
+Then, enter the command `snakemake -j 2` and allow the pipeline to run.
 If you uploaded a single protein, it should take about 1-2 minutes.
 As the pipeline starts, you should see something like:
 

--- a/Snakefile
+++ b/Snakefile
@@ -27,7 +27,6 @@ rule mafft_multiple_sequence_align_query_protein_and_confident_actins:
     '''
     input: "outputs/mean_pid/{query_protein}_combined.fasta"
     output: "outputs/mean_pid/{query_protein}_msa.fasta"
-    conda: "envs/mafft.yml"
     benchmark: "benchmarks/msa_with_confident_actins_{query_protein}.txt"
     shell:'''
     mafft-linsi {input} > {output}
@@ -39,7 +38,6 @@ rule calculate_pairwise_identity:
     output: 
         tsv = "outputs/mean_pid/{query_protein}_pid.tsv",
         pdf = "outputs/mean_pid/{query_protein}_pid.pdf",
-    conda: "envs/tidybio3d.yml"
     benchmark: "benchmarks/calculate_pid_{query_protein}.txt"
     script: "snakemake/snakemake_calculate_pairwise_identity.R"
 
@@ -48,7 +46,6 @@ rule combine_pairwise_identity_outputs:
     output:
         pid = "outputs/mean_pid/all_pid.tsv",
         avg_pid = "outputs/mean_pid/all_avg_pid.tsv"
-    conda: "envs/tidyverse.yml"
     benchmark: "benchmarks/combine_pid.txt"
     script: "snakemake/snakemake_combine_pairwise_identity_outputs.R"
 
@@ -75,7 +72,6 @@ rule mafft_align_query_protein_to_human_beta_actin:
     output:
         mafft_map = "query_proteins/{query_protein}.fasta.map",
         alignment= "outputs/shared_feature_residues/0_mafft/{query_protein}_vs_P60709_ACTB_HUMAN.fasta"
-    conda: "envs/mafft.yml"
     benchmark: "benchmarks/mafft_human_beta_actin_{query_protein}.txt"
     shell:'''
     mafft --auto --mapout --keeplength --add {input.query_fasta} {input.human_beta_actin} > {output.alignment}
@@ -92,7 +88,6 @@ rule calculate_shared_feature_residues:
     output:
         tsv="outputs/shared_feature_residues/1_shared_residue_information/{query_protein}-{features}.tsv",
         tsv_summary="outputs/shared_feature_residues/2_shared_residue_summaries/{query_protein}-{features}.tsv"
-    conda: "envs/tidyverse.yml"
     benchmark: "benchmarks/calculate_shared_feature_residues_{query_protein}_{features}.txt"
     script: "snakemake/snakemake_calculate_shared_feature_residues.R"
 
@@ -100,7 +95,6 @@ rule combine_shared_feature_residue_outputs:
     input: 
         tsv_summaries = expand("outputs/shared_feature_residues/2_shared_residue_summaries/{query_protein}-{features}.tsv", query_protein = config["query_protein"], features = config["features"])
     output: all_features = "outputs/shared_feature_residues/3_shared_residue_summaries_combined/all_shared_residues_combined.tsv"
-    conda: "envs/tidyverse.yml"
     benchmark: "benchmarks/combine_shared_feature_residues.txt"
     script: "snakemake/snakemake_combine_shared_feature_residue_outputs.R"
 
@@ -125,7 +119,6 @@ rule download_pfam:
 rule hmmpress:
     input: "inputs/pfam/PF00022.hmm"
     output: "inputs/pfam/PF00022.hmm.h3i"
-    conda: "envs/hmmer.yml"
     benchmark: "benchmarks/hmm/PF00022-hmmpress.txt"
     shell:'''
     hmmpress {input}
@@ -140,7 +133,6 @@ rule hmmscan:
         out = "outputs/hmm/hmmscan/{query_protein}-PF00022-hmmscan.out",
         tbl = "outputs/hmm/hmmscan/{query_protein}-PF00022-hmmscan-tbl.out",
         dom = "outputs/hmm/hmmscan/{query_protein}-PF00022-hmmscan-dom.out"
-    conda: "envs/hmmer.yml"
     benchmark: "benchmarks/hmm/hmmscan_{query_protein}.txt"
     shell:'''
     hmmscan --cut_ga -o {output.out} --tblout {output.tbl} --domtblout {output.dom} {input.hmm} {input.query_protein} 
@@ -148,7 +140,6 @@ rule hmmscan:
 
 rule download_hmm_parser:
     output: "scripts/rhmmer_parse.R"
-    conda: "envs/curl.yml"
     shell:'''
     curl -JLo {output} https://raw.githubusercontent.com/arendsee/rhmmer/master/R/parse.R
     '''
@@ -158,7 +149,6 @@ rule combine_hmm_outputs:
         rhmmer = "scripts/rhmmer_parse.R",
         tbl = expand("outputs/hmm/hmmscan/{query_protein}-PF00022-hmmscan-tbl.out", query_protein = config["query_protein"]) 
     output: all_hmm = "outputs/hmm/hmmscan/all-hmmscan-tbl-out.tsv"
-    conda: "envs/tidyverse.yml"
     benchmark: "benchmarks/combine_hmm.txt"
     script: "snakemake/snakemake_combine_hmm_outputs.R"
 
@@ -174,7 +164,6 @@ checkpoint chunk_genbank_accessions_for_uniprot_id_conversion:
     '''
     input: fastas=expand("query_proteins/{query_protein}.fasta", query_protein = config["query_protein"])
     output: outdir=directory("outputs/foldseek/chunked_accessions/")
-    conda: "envs/tidyverse.yml"
     benchmark: "benchmarks/foldseek/chunk_query_proteins.txt"
     script: "snakemake/snakemake_chunk_genbank_accessions_for_uniprot_id_conversion.R" 
 
@@ -208,7 +197,6 @@ rule convert_genbank_protein_accession_to_uniprot_accessions:
         query="outputs/foldseek/uniprot_accessions/query{grp}.txt",
         query_status="outputs/foldseek/uniprot_accessions/query_status{grp}.txt",
         results="outputs/foldseek/uniprot_accessions/results{grp}.txt"
-    conda: "envs/curl.yml"
     benchmark: "benchmarks/foldseek/convert_genbank_to_uniprot{grp}.txt"
     shell:"""
     # submit the curl "form" to uniprot to start the query
@@ -252,20 +240,17 @@ def chunk_genbank_accessions_for_uniprot_id_conversion(wildcards):
 rule combine_uniprot_id_conversions:
     input: results=chunk_genbank_accessions_for_uniprot_id_conversion,
     output: tsv = "outputs/foldseek/uniprot_accessions/results.tsv"
-    conda: "envs/tidyverse.yml"
     benchmark: "benchmarks/foldseek/convert_genbank_to_uniprot_combine_results.txt"
     script: "snakemake/snakemake_combine_uniprot_id_conversions.R"
 
 checkpoint create_dummy_files_for_uniprot_accession_wildcard:
     input: tsv = "outputs/foldseek/uniprot_accessions/results.tsv"
     output: outdir = directory("outputs/foldseek/uniprot_accessions_wc/")
-    conda: "envs/tidyverse.yml"
     script: "snakemake/snakemake_create_dummy_files_for_uniprot_accession_wildcard.R"
 
 rule download_alphafold_pdb_files_for_uniprot_accessions:
     input: "outputs/foldseek/uniprot_accessions_wc/{uniprot_acc}.txt"
     output: "outputs/foldseek/uniprot_alphafold_pdb_structures/AF-{uniprot_acc}-F1-model_V4.pdb"
-    conda: "envs/curl.yml"
     benchmark: "benchmarks/foldseek/download_alphafold_pdb_files/{uniprot_acc}.txt"
     shell:'''
     curl -JLo {output} https://alphafold.ebi.ac.uk/files/AF-{wildcards.uniprot_acc}-F1-model_v4.pdb
@@ -288,7 +273,6 @@ rule run_foldseek:
         query = "outputs/foldseek/uniprot_alphafold_pdb_structures/AF-{uniprot_acc}-F1-model_V4.pdb"
     output: "outputs/foldseek/foldseek/{uniprot_acc}_vs_1j6z.tsv"
     params: refdir = "inputs/pdb/"
-    conda: "envs/foldseek.yml"
     shell:'''
     mkdir -p tmp_foldseek_folder
     foldseek easy-search {input.query} {params.refdir} {output} tmp_foldseek_folder 
@@ -299,7 +283,6 @@ rule combine_foldseek_outputs:
         uniprot_acc = "outputs/foldseek/uniprot_accessions/results.tsv",
         fsk = create_dummy_files_for_uniprot_accession_wildcard
     output: all_fsk  = "outputs/foldseek/foldseek/all_foldseek.tsv"
-    conda: "envs/tidyverse.yml"
     benchmark: "benchmarks/combine_foldseek.txt"
     script: "snakemake/snakemake_combine_foldseek_outputs.R"
 
@@ -314,6 +297,5 @@ rule combine_all_outputs:
         all_hmm = "outputs/hmm/hmmscan/all-hmmscan-tbl-out.tsv",
         all_fsk  = "outputs/foldseek/foldseek/all_foldseek.tsv",
     output: all_outputs = "outputs/all_outputs_summarized.tsv"
-    conda: "envs/tidyverse.yml"
     benchmark: "benchmarks/combine_all_outputs.txt"
     script: "snakemake/snakemake_combine_all_outputs.R"

--- a/actin_env.yml
+++ b/actin_env.yml
@@ -1,0 +1,6 @@
+channels:
+   - conda-forge
+   - bioconda
+   - defaults
+dependencies:
+   - snakemake-minimal=7.20.0

--- a/environment.yml
+++ b/environment.yml
@@ -4,3 +4,12 @@ channels:
    - defaults
 dependencies:
    - snakemake-minimal=7.20.0
+   - blast=2.12.0
+   - curl=7.86.0
+   - entrez-direct=16.2
+   - foldseek=3.915ef7d
+   - hmmer=3.3.2
+   - mafft=7.508
+   - r-bio3d=2.4_3
+   - r-tidyverse=1.3.2
+   - r-showtext=0.9


### PR DESCRIPTION
With pangeo binder being sunsetted, we now need to be more conscious of how much RAM we use in binder. Unfortunately, building conda environments takes more ram than the binder has. This PR:
1. switches to mybinder.org
2. builds a base conda env that has all of the req'd software for the environment in it. This way, everything is already installed
3. switches up the docs on the environments for local vs. binder use (binder will use `environment.yml` by default)
4. reduces threads for running snakemake within the binder

Click the button below to launch from this PR. The launch button in the readme will launch from `main`, which is the correct thing to do after this PR is merged.

[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/Arcadia-Science/2022-actin-prediction/binder)